### PR TITLE
A few things

### DIFF
--- a/src/AtomAnimations/AtomAnimationEditContext.cs
+++ b/src/AtomAnimations/AtomAnimationEditContext.cs
@@ -236,7 +236,7 @@ namespace VamTimeline
             {
                 animation.PlayClip(current, animation.sequencing);
             }
-            else
+            else if (!SuperController.singleton.freezeAnimation)
             {
                 Sample();
             }

--- a/src/AtomAnimations/AtomClipboardEntry.cs
+++ b/src/AtomAnimations/AtomClipboardEntry.cs
@@ -21,6 +21,17 @@ namespace VamTimeline
         public List<FreeControllerV3ClipboardEntry> controllers;
         public List<FloatParamValClipboardEntry> floatParams;
         public List<TriggersClipboardEntry> triggers;
+
+		public bool Empty
+		{
+			get
+			{
+				return
+					controllers.Count == 0 &&
+					floatParams.Count == 0 &&
+					triggers.Count == 0;
+			}
+		}
     }
 
     public class FloatParamValClipboardEntry

--- a/src/AtomAnimations/IAtomAnimationTarget.cs
+++ b/src/AtomAnimations/IAtomAnimationTarget.cs
@@ -26,5 +26,7 @@ namespace VamTimeline
 
         ISnapshot GetSnapshot(float time);
         void SetSnapshot(float time, ISnapshot snapshot);
+
+		void SelectInVam();
     }
 }

--- a/src/AtomAnimations/Targets/AnimationTargetBase.cs
+++ b/src/AtomAnimations/Targets/AnimationTargetBase.cs
@@ -36,6 +36,11 @@ namespace VamTimeline
             if (_bulk == 0 && dirty) onAnimationKeyframesDirty.Invoke();
         }
 
+		public void SelectInVam()
+		{
+			// no-op
+		}
+
         public virtual void Dispose()
         {
             onAnimationKeyframesDirty.RemoveAllListeners();

--- a/src/AtomAnimations/Targets/FreeControllerAnimationTarget.cs
+++ b/src/AtomAnimations/Targets/FreeControllerAnimationTarget.cs
@@ -158,6 +158,11 @@ namespace VamTimeline
             }
         }
 
+		public void SelectInVam()
+		{
+            SuperController.singleton.SelectController(controller);
+		}
+
         #region Keyframes control
 
         public int SetKeyframeToCurrentTransform(float time)

--- a/src/AtomPlugin.cs
+++ b/src/AtomPlugin.cs
@@ -718,15 +718,25 @@ namespace VamTimeline
             try
             {
                 if (!animationEditContext.CanEdit()) return;
-                clipboard.Clear();
-                var time = animationEditContext.clipTime;
-                clipboard.time = time;
-                clipboard.entries.Add(animationEditContext.current.Copy(clipboard.time, animationEditContext.GetAllOrSelectedTargets()));
-                if (time.IsSameFrame(0f) || time.IsSameFrame(animationEditContext.current.animationLength)) return;
-                foreach (var target in animationEditContext.GetAllOrSelectedTargets())
-                {
-                    target.DeleteFrame(time);
-                }
+
+				var time = animationEditContext.clipTime;
+				var entry = animationEditContext.current.Copy(time, animationEditContext.GetAllOrSelectedTargets());
+
+				if (entry.Empty)
+				{
+                    SuperController.LogMessage("Timeline: Nothing to cut");
+				}
+				else
+				{
+					clipboard.Clear();
+					clipboard.time = time;
+					clipboard.entries.Add(entry);
+					if (time.IsSameFrame(0f) || time.IsSameFrame(animationEditContext.current.animationLength)) return;
+					foreach (var target in animationEditContext.GetAllOrSelectedTargets())
+					{
+						target.DeleteFrame(time);
+					}
+				}
             }
             catch (Exception exc)
             {
@@ -739,9 +749,20 @@ namespace VamTimeline
             try
             {
                 if (!animationEditContext.CanEdit()) return;
-                clipboard.Clear();
-                clipboard.time = animationEditContext.clipTime;
-                clipboard.entries.Add(animationEditContext.current.Copy(clipboard.time, animationEditContext.GetAllOrSelectedTargets()));
+
+				var time = animationEditContext.clipTime;
+				var entry = animationEditContext.current.Copy(time, animationEditContext.GetAllOrSelectedTargets());
+
+				if (entry.Empty)
+				{
+                    SuperController.LogMessage("Timeline: Nothing to copy");
+				}
+				else
+				{
+					clipboard.Clear();
+					clipboard.time = time;
+					clipboard.entries.Add(entry);
+				}
             }
             catch (Exception exc)
             {

--- a/src/UI/Components/Clickable.cs
+++ b/src/UI/Components/Clickable.cs
@@ -7,10 +7,17 @@ namespace VamTimeline
     public class Clickable : MonoBehaviour, IPointerClickHandler
     {
         public ClickableEvent onClick = new ClickableEvent();
+		public ClickableEvent onLeftClick = new ClickableEvent();
+		public ClickableEvent onRightClick = new ClickableEvent();
 
         public void OnPointerClick(PointerEventData eventData)
         {
             onClick.Invoke(eventData);
+
+			if (eventData.button == PointerEventData.InputButton.Left)
+				onLeftClick?.Invoke(eventData);
+			else if (eventData.button == PointerEventData.InputButton.Right)
+				onRightClick?.Invoke(eventData);
         }
 
         public void OnDestroy()

--- a/src/UI/Components/DopeSheet/DopeSheet.cs
+++ b/src/UI/Components/DopeSheet/DopeSheet.cs
@@ -282,9 +282,15 @@ namespace VamTimeline
                 );
 
                 var click = child.AddComponent<Clickable>();
-                click.onClick.AddListener(_ =>
+
+                click.onLeftClick.AddListener(_ =>
                 {
                     _animationEditContext.SetSelected(target, !_animationEditContext.IsSelected(target));
+                });
+
+                click.onRightClick.AddListener(_ =>
+                {
+					target.SelectInVam();
                 });
             }
 

--- a/src/UI/Components/TargetFrame/ControllerTargetFrame.cs
+++ b/src/UI/Components/TargetFrame/ControllerTargetFrame.cs
@@ -122,7 +122,7 @@ namespace VamTimeline
             group.padding = new RectOffset(8, 8, 8, 8);
             group.childAlignment = TextAnchor.MiddleCenter;
 
-            CreateExpandButton(group.transform, "Select", () => SuperController.singleton.SelectController(target.controller));
+            CreateExpandButton(group.transform, "Select", () => target.SelectInVam());
 
             CreateExpandButton(group.transform, "Settings", () =>
             {


### PR DESCRIPTION
### When selecting an animation, don't sample if vam is frozen
This adds a check for `freezeAnimation` in `SelectAnimation()`. It doesn't prevent sampling when moving the scrubber, which I think should still work because it's a manual user input. This just avoids jumps when selecting animations.

### Don't clear the clipboard when there are no keyframes at the current time
I added an `Empty` property to `AtomClipboardEntry` that returns `true` if all lists are empty. When that happens, I log a message similar to "Clipboard is empty" and do nothing. This prevents from clearing the clipboard if there's nothing to cut or copy.

### Select controller when right-clicking the button in the dope sheet
I added a new `SelectInVam()` in `IAtomAnimationTarget`. It's implemented as a no-op in `AnimationTargetBase`, but `FreeControllerAnimationTarget` overrides it to select the controller. I chose the name to avoid confusion with selection within Timeline.

There are two new events in `Clickable` to distinguish between left and right clicks, which were both firing the same `onClick` event, but I kept `onClick` as-is to keep the old behaviour for everything else. I also changed the "Select" button in `ControllerTargetFrame` to call the new function.
