### PR TITLE
Show paths option

### DIFF
--- a/src/AtomAnimations/AtomAnimationEditContext.cs
+++ b/src/AtomAnimations/AtomAnimationEditContext.cs
@@ -36,6 +36,12 @@ namespace VamTimeline
             get { return _autoKeyframeAllControllers; }
             set { _autoKeyframeAllControllers = value; onEditorSettingsChanged.Invoke(nameof(autoKeyframeAllControllers)); }
         }
+        private bool _showPaths = true;
+        public bool showPaths
+        {
+            get { return _showPaths; }
+            set { _showPaths = value; }
+        }
         private bool _locked;
         public bool locked
         {

--- a/src/UI/Components/TargetFrame/ControllerTargetFrame.cs
+++ b/src/UI/Components/TargetFrame/ControllerTargetFrame.cs
@@ -31,6 +31,7 @@ namespace VamTimeline
             {
                 _line = CreateLine();
                 UpdateLine();
+                _line.transform.gameObject.SetActive(plugin.animationEditContext.showPaths);
             }
         }
 

--- a/src/UI/Screens/OptionsScreen.cs
+++ b/src/UI/Screens/OptionsScreen.cs
@@ -6,6 +6,7 @@ namespace VamTimeline
         private JSONStorableBool _lockedJSON;
         private JSONStorableFloat _snapJSON;
         private JSONStorableBool _autoKeyframeAllControllersJSON;
+        private JSONStorableBool _showPaths;
 
         public override string screenId => ScreenName;
 
@@ -32,6 +33,12 @@ namespace VamTimeline
             InitAutoKeyframeUI();
 
             animationEditContext.onEditorSettingsChanged.AddListener(OnEditorSettingsChanged);
+
+            _showPaths = new JSONStorableBool(
+                "Show paths", animationEditContext.showPaths,
+                val => animationEditContext.showPaths = val);
+
+            prefabFactory.CreateToggle(_showPaths);
         }
 
         private void InitLockedUI()


### PR DESCRIPTION
Adds a "Show paths" checkbox in the options screen and calls `SetActive()` on the line to hide it. When unchecked, this completely hides the controller paths on screen, which can sometimes be annoying.