### PR TITLE
Move by snap amount when right-clicking frame buttons

### DIFF
--- a/src/UI/Components/AnimationControlPanel/AnimationControlPanel.cs
+++ b/src/UI/Components/AnimationControlPanel/AnimationControlPanel.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Linq;
 using UnityEngine;
 using UnityEngine.Events;
+using UnityEngine.EventSystems;
 using UnityEngine.UI;
 
 namespace VamTimeline
@@ -122,7 +123,11 @@ namespace VamTimeline
             gridLayout.childForceExpandWidth = false;
             gridLayout.childControlWidth = true;
 
-            CreateSmallButton(buttonPrefab, container.transform, "<\u0192", () => _animationEditContext.PreviousFrame());
+            CreateSmallButton(
+				buttonPrefab, container.transform, "<\u0192",
+				() => _animationEditContext.PreviousFrame(),
+				() => _animationEditContext.RewindSeconds(_animationEditContext.snap));
+
 
             CreateSmallButton(buttonPrefab, container.transform, "-1s", () => _animationEditContext.RewindSeconds(1f));
 
@@ -134,16 +139,27 @@ namespace VamTimeline
 
             CreateSmallButton(buttonPrefab, container.transform, "+1s", () => _animationEditContext.ForwardSeconds(1f));
 
-            CreateSmallButton(buttonPrefab, container.transform, "\u0192>", () => _animationEditContext.NextFrame());
+            CreateSmallButton(
+				buttonPrefab, container.transform, "\u0192>",
+				() => _animationEditContext.NextFrame(),
+				() => _animationEditContext.ForwardSeconds(_animationEditContext.snap));
         }
 
-        private static void CreateSmallButton(Transform buttonPrefab, Transform parent, string label, UnityAction callback)
+        private static void CreateSmallButton(Transform buttonPrefab, Transform parent, string label, UnityAction leftClick, UnityAction rightClick=null)
         {
             var btn = Instantiate(buttonPrefab, parent, false);
             var ui = btn.GetComponent<UIDynamicButton>();
             ui.label = label;
             ui.buttonText.fontSize = 27;
-            ui.button.onClick.AddListener(callback);
+
+			var click = btn.gameObject.AddComponent<Clickable>();
+
+			if (leftClick != null)
+				click.onClick.AddListener(eventData => leftClick());
+
+			if (rightClick != null)
+				click.onRightClick.AddListener(eventData => rightClick());
+
             var layoutElement = btn.GetComponent<LayoutElement>();
             layoutElement.preferredWidth = 0;
             layoutElement.flexibleWidth = 20;

--- a/src/UI/Components/AnimationControlPanel/AnimationControlPanel.cs
+++ b/src/UI/Components/AnimationControlPanel/AnimationControlPanel.cs
@@ -124,9 +124,9 @@ namespace VamTimeline
             gridLayout.childControlWidth = true;
 
             CreateSmallButton(
-				buttonPrefab, container.transform, "<\u0192",
-				() => _animationEditContext.PreviousFrame(),
-				() => _animationEditContext.RewindSeconds(_animationEditContext.snap));
+                buttonPrefab, container.transform, "<\u0192",
+                () => _animationEditContext.PreviousFrame(),
+                () => _animationEditContext.RewindSeconds(_animationEditContext.snap));
 
 
             CreateSmallButton(buttonPrefab, container.transform, "-1s", () => _animationEditContext.RewindSeconds(1f));
@@ -140,9 +140,9 @@ namespace VamTimeline
             CreateSmallButton(buttonPrefab, container.transform, "+1s", () => _animationEditContext.ForwardSeconds(1f));
 
             CreateSmallButton(
-				buttonPrefab, container.transform, "\u0192>",
-				() => _animationEditContext.NextFrame(),
-				() => _animationEditContext.ForwardSeconds(_animationEditContext.snap));
+                buttonPrefab, container.transform, "\u0192>",
+                () => _animationEditContext.NextFrame(),
+                () => _animationEditContext.ForwardSeconds(_animationEditContext.snap));
         }
 
         private static void CreateSmallButton(Transform buttonPrefab, Transform parent, string label, UnityAction leftClick, UnityAction rightClick=null)
@@ -152,13 +152,13 @@ namespace VamTimeline
             ui.label = label;
             ui.buttonText.fontSize = 27;
 
-			var click = btn.gameObject.AddComponent<Clickable>();
+            var click = btn.gameObject.AddComponent<Clickable>();
 
-			if (leftClick != null)
-				click.onClick.AddListener(eventData => leftClick());
+            if (leftClick != null)
+                click.onClick.AddListener(eventData => leftClick());
 
-			if (rightClick != null)
-				click.onRightClick.AddListener(eventData => rightClick());
+            if (rightClick != null)
+                click.onRightClick.AddListener(eventData => rightClick());
 
             var layoutElement = btn.GetComponent<LayoutElement>();
             layoutElement.preferredWidth = 0;


### PR DESCRIPTION
If the snap amount is small and the animation long, it becomes really difficult to click the scrubber to move to a specific time. For example, a 20s animation with a 0.05 snap time makes some frames actually impossible to click. This adds right-click handlers to the `< f` and `f >` buttons that move the scrubber by the snap time.

I reused the `Clickable` component and added an additional `rightClick` parameter for the callback that defaults to `null`.

Also, one day I'll remember the tab settings before my commit.