### PR TITLE
Add time remaining storable

### DIFF
--- a/src/AtomAnimations/AtomAnimation.cs
+++ b/src/AtomAnimations/AtomAnimation.cs
@@ -69,6 +69,26 @@ namespace VamTimeline
             }
         }
 
+        public float timeRemaining
+        {
+            get
+            {
+                for (var i = 0; i < clips.Count; ++i)
+                {
+                    var clip = clips[i];
+
+                    if (clip.playbackEnabled)
+                    {
+                        var length = clip.animationLength;
+                        var time = clip.clipTime;
+                        return length - time;
+                    }
+                }
+
+                return 0;
+            }
+        }
+
         private float _speed = 1f;
         public float speed
         {

--- a/src/AtomPlugin.cs
+++ b/src/AtomPlugin.cs
@@ -41,6 +41,7 @@ namespace VamTimeline
         public JSONStorableFloat speedJSON { get; private set; }
         public JSONStorableBool lockedJSON { get; private set; }
         public JSONStorableBool pausedJSON { get; private set; }
+        public JSONStorableFloat timeRemainingJSON { get; private set; }
 
         private JSONStorableFloat _scrubberAnalogControlJSON;
         private bool _scrubbing = false;
@@ -135,6 +136,7 @@ namespace VamTimeline
             {
                 scrubberJSON.valNoCallback = animationEditContext.clipTime;
                 timeJSON.valNoCallback = animation.playTime;
+                timeRemainingJSON.valNoCallback = animation.timeRemaining;
             }
 
             if (_scrubberAnalogControlJSON.val != 0)
@@ -303,6 +305,10 @@ namespace VamTimeline
                 isRestorable = false
             };
             RegisterBool(isPlayingJSON);
+
+
+            timeRemainingJSON = new JSONStorableFloat(StorableNames.TimeRemaining, 0f, 0f, float.MaxValue);
+            RegisterFloat(timeRemainingJSON);
 
             stopJSON = new JSONStorableAction(StorableNames.Stop, () =>
             {
@@ -703,6 +709,7 @@ namespace VamTimeline
         private void OnIsPlayingChanged(AtomAnimationClip clip)
         {
             isPlayingJSON.valNoCallback = animation.isPlaying;
+            timeRemainingJSON.valNoCallback = animation.isPlaying ? animation.timeRemaining : 0;
             _freeControllerHook.enabled = !animation.isPlaying;
             peers.SendPlaybackState(clip);
         }

--- a/src/Common/StorableNames.cs
+++ b/src/Common/StorableNames.cs
@@ -10,6 +10,7 @@ namespace VamTimeline
         public const string Play = "Play";
         public const string PlayIfNotPlaying = "Play If Not Playing";
         public const string IsPlaying = "Is Playing";
+        public const string TimeRemaining = "Time Remaining";
         public const string Stop = "Stop";
         public const string StopIfPlaying = "Stop If Playing";
         public const string StopAndReset = "Stop And Reset";


### PR DESCRIPTION
- Added `AtomAnimation.timeRemaining`, returns the time remaining for the first enabled clip. I'm assuming this should typically be the active animation.
- The storable is set to `0` in `OnIsPlayingChanged()` when playback is stopped.