### PR TITLE
Fix issue with comply being paused even when forced is set to false

### DIFF
--- a/src/AtomAnimations/Animations/AtomAnimation.Playback.cs
+++ b/src/AtomAnimations/Animations/AtomAnimation.Playback.cs
@@ -766,8 +766,10 @@ namespace VamTimeline
                 control.position = position;
             }
 
-            if (force && controller.currentPositionState == FreeControllerV3.PositionState.Comply || controller.currentRotationState == FreeControllerV3.RotationState.Comply)
+            if (force && (controller.currentPositionState == FreeControllerV3.PositionState.Comply ||
+                controller.currentRotationState == FreeControllerV3.RotationState.Comply)) {
                 controller.PauseComply();
+            }
         }
 
         #endregion


### PR DESCRIPTION
The conditional had a structural error which meant that a target controller with "control position / rotation" both unchecked (and both position and rotation set to Comply) would pause comply during playback, locking the controller in place.  This appears to be unintended behavior.